### PR TITLE
Redirect users to get_next_url(avatar) on login

### DIFF
--- a/jhub_cas_authenticator/cas_auth.py
+++ b/jhub_cas_authenticator/cas_auth.py
@@ -76,7 +76,7 @@ class CASLoginHandler(BaseHandler):
                 app_log.debug("CAS authentication successful for '{0}'.".format(user))
                 avatar = self.user_from_username(user)
                 self.set_login_cookie(avatar)
-                self.redirect(url_path_join(self.hub.server.base_url, 'home'))
+                self.redirect(self.get_next_url(avatar))
             else:
                 raise web.HTTPError(401)
 


### PR DESCRIPTION
Matches redirect in LoginHandler: jupyterhub/handlers/login.py:87
Enables redirect when logging in from non-root directories.
Enables redirect to user dir if redirect_to_server is set.
E.g., if using Jupyterlab, this now correctly redirects into the Jupyterlab IDE.