### PR TITLE
Fix/update asyncio use (matches JupyterHub 1.0)

### DIFF
--- a/jhub_cas_authenticator/cas_auth.py
+++ b/jhub_cas_authenticator/cas_auth.py
@@ -7,7 +7,7 @@ from jupyterhub.auth import (
     LocalAuthenticator,
 )
 from lxml import etree
-from tornado import gen, web
+from tornado import web
 from tornado.httpclient import (
     AsyncHTTPClient,
     HTTPError,
@@ -24,9 +24,8 @@ class CASLogoutHandler(BaseHandler):
     to the CAS logout URL.
     """
 
-    @gen.coroutine
-    def get(self):
-        user = self.get_current_user()
+    async def get(self):
+        user = await self.get_current_user()
         if user:
             self.log.info("User logged out: %s", user.name)
             self.clear_login_cookie()
@@ -42,8 +41,7 @@ class CASLoginHandler(BaseHandler):
     Authenticate users via the CAS protocol.
     """
 
-    @gen.coroutine
-    def get(self):
+    async def get(self):
         app_log = logging.getLogger("tornado.application")
         ticket = self.get_argument("ticket", None)
         has_service_ticket = ticket is not None
@@ -61,7 +59,7 @@ class CASLoginHandler(BaseHandler):
 
         # Validate ticket
         app_log.debug("Validating service ticket {0}...".format(ticket[:10]))
-        result = yield self.validate_service_ticket(ticket)
+        result = await self.validate_service_ticket(ticket)
         is_valid, user, attributes = result
         if not is_valid:
             raise web.HTTPError(401)
@@ -103,8 +101,7 @@ class CASLoginHandler(BaseHandler):
             cas_service_url = self.request.protocol + "://" + self.request.host + self.request.uri
         return cas_service_url
 
-    @gen.coroutine
-    def validate_service_ticket(self, ticket):
+    async def validate_service_ticket(self, ticket):
         """
         Validate a CAS service ticket.
 
@@ -121,7 +118,7 @@ class CASLoginHandler(BaseHandler):
         response = None
         app_log.debug("Validate URL: {0}".format(cas_validate_url))
         try:
-            response = yield http_client.fetch(
+            response = await http_client.fetch(
                 cas_validate_url,
                 method="GET",
                 ca_certs=self.authenticator.cas_client_ca_certs)
@@ -187,8 +184,7 @@ class CASAuthenticator(Authenticator):
             (r'/logout', CASLogoutHandler),
         ]
 
-    @gen.coroutine
-    def authenticate(self, *args):
+    async def authenticate(self, *args):
         raise NotImplementedError()
 
 
@@ -231,8 +227,7 @@ class CASLocalAuthenticator(LocalAuthenticator):
             (r'/logout', CASLogoutHandler),
         ]
 
-    @gen.coroutine
-    def authenticate(self, *args):
+    async def authenticate(self, *args):
         raise NotImplementedError()
 
 

--- a/jhub_cas_authenticator/cas_auth.py
+++ b/jhub_cas_authenticator/cas_auth.py
@@ -25,7 +25,7 @@ class CASLogoutHandler(BaseHandler):
     """
 
     async def get(self):
-        user = await self.get_current_user()
+        user = self.current_user
         if user:
             self.log.info("User logged out: %s", user.name)
             self.clear_login_cookie()


### PR DESCRIPTION
Logout was failing with a 500 server error because `self.get_current_user()` was returning a coroutine.  I'm not sure when that changed, but I expect it was with JupyterHub 1.0.

While trying to fix that, I ended up shifting everything over to the `async def` / `await` syntax, away from Tornado's `@gen.coroutine` and `yield`.  I am not certain that I've done this correctly, but:
1. Login and logout work in my tests.
2. It matches the uses of `async def` and `await` in Jupyterhub's [`login.py`](https://github.com/jupyterhub/jupyterhub/blob/master/jupyterhub/handlers/login.py) handler.  This appears to have changed in jupyterhub/jupyterhub@7a268c9.

I've tested this with Jupyterhub 1.0.  I'm not sure whether the changes would work with previous versions of jupyterhub.  This may just be a v1.0+ only change.